### PR TITLE
fix clang compiler warning

### DIFF
--- a/dragon.c
+++ b/dragon.c
@@ -93,6 +93,8 @@ if (last==1)return 90;
   if(last==6)return 90;
   if(last==7)return -90;
 
+  return last;
+
 }
 
 /* print the curvilinier coordinate system */


### PR DESCRIPTION
Cosmetic fix for "warning control may reach end of non-void function" using clang compiler.